### PR TITLE
Added wpa_cli functionality in rpi3.mk

### DIFF
--- a/rpi3.mk
+++ b/rpi3.mk
@@ -46,7 +46,8 @@ PRODUCT_PACKAGES += \
     wificond \
     wifilogd \
     wpa_supplicant \
-    wpa_supplicant.conf
+    wpa_supplicant.conf \
+    wpa_cli
 
 # hardware/interfaces
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
wpa_cli is a text-based frontend program for interacting with wpa_supplicant. It is used to query current status, change configuration, trigger events, and request interactive user input.